### PR TITLE
Export battery states to consumers, simplify return values.

### DIFF
--- a/example_battery.py
+++ b/example_battery.py
@@ -13,3 +13,4 @@ battery = pychonet.StorageBattery("10.0.0.1")
 print(battery.getAllPropertyMaps())
 
 print(battery.getRemainingStoredElectricity3())
+print(battery.WORKING_OPERATION_STATES[battery.getWorkingOperationStatus()])

--- a/pychonet/StorageBattery.py
+++ b/pychonet/StorageBattery.py
@@ -1,10 +1,9 @@
 from pychonet.EchonetInstance import EchonetInstance
 
-def _027de4(edt):
-    return {'remaining_electricity_3': int.from_bytes(edt, 'big')}
+class StorageBattery(EchonetInstance):
 
-def _027dcf(edt):
-    STATES = {
+    WORKING_OPERATION_STATES = {
+        0x40: "Other",
         0x41: "Rapid charging",
         0x42: "Charging",
         0x43: "Discharging",
@@ -15,16 +14,13 @@ def _027dcf(edt):
         0x49: "Effective capacity recalculation processing"
     }
 
-    return {"working_operation_status": STATES[int.from_bytes(edt, 'big')]}
-
-class StorageBattery(EchonetInstance):
     def __init__(self, netif, instance = 0x1):
         self.eojgc = 0x02
         self.eojcc = 0x7d
         EchonetInstance.__init__(self, self.eojgc, self.eojcc, instance, netif)
 
     def getRemainingStoredElectricity3(self):
-        return _027de4(self.getSingleMessageResponse(0xE4))
+        return int.from_bytes(self.getSingleMessageResponse(0xE4), 'big')
 
     def getWorkingOperationStatus(self):
-        return _027dcf(self.getSingleMessageResponse(0xCF))
+        return int.from_bytes(self.getSingleMessageResponse(0xCF), 'big')


### PR DESCRIPTION
I think it makes sense to return scalars where possible and leave to higher level libraries/apps to potentially turn those into JSON objects. This way, we don't have to worry about coming up with and maintaining a schema for return values.