### PR TITLE
Fix typo

### DIFF
--- a/pychonet/lib/const.py
+++ b/pychonet/lib/const.py
@@ -250,9 +250,9 @@ MANUFACTURERS = {
     0x0000F9: 'Toho Electronics',
     0x0000FA: 'Plat Home',
     0x0000FB: 'CICO',
-    0x0000FC: 'Fuji Industrial'
-    0xFFFFFE: 'Undefined'
-    0xFFFFFF: 'Experimental',
+    0x0000FC: 'Fuji Industrial',
+    0xFFFFFE: 'Undefined',
+    0xFFFFFF: 'Experimental'
 }
 
 ENL_ON = 0x30

--- a/pychonet/lib/epc_functions.py
+++ b/pychonet/lib/epc_functions.py
@@ -59,7 +59,6 @@ def _009A(edt): #cumulative runtime
 
 EPC_SUPER_FUNCTIONS = {
     0x80: _0080,
-    0x8A: _int,
     0x83: _0083,
     0x85: _int,
     0x8A: _008A,


### PR DESCRIPTION
I'm quite sorry, a fatal mistake was included in #8.

In addition, I deleted the old process for `0x8A` included in `EPC_SUPER_FUNCTIONS`.