### PR TITLE
Fix class variable instantiation and method return types

### DIFF
--- a/pychonet/ElectricVehicleCharger.py
+++ b/pychonet/ElectricVehicleCharger.py
@@ -4,6 +4,6 @@ from pychonet.EchonetInstance import EchonetInstance
 class ElectricVehicleCharger(EchonetInstance):
 
     def __init__(self, host, api_connector = None, instance = 0x1):
-        self.eojgc = 0x02 # Housing/facility-related device group
-        self.eojcc = 0x7e # Electric vehicle charger/discharger’
+        self._eojgc = 0x02 # Housing/facility-related device group
+        self._eojcc = 0x7e # Electric vehicle charger/discharger’
         EchonetInstance.__init__(self, host, self._eojgc, self._eojcc, instance, api_connector)

--- a/pychonet/HomeSolarPower.py
+++ b/pychonet/HomeSolarPower.py
@@ -2,12 +2,12 @@ from pychonet.EchonetInstance import EchonetInstance
 
 class HomeSolarPower(EchonetInstance):
     def __init__(self, host, api_connector, instance = 0x1):
-        self.eojgc = 0x02
-        self.eojcc = 0x79
+        self._eojgc = 0x02
+        self._eojcc = 0x79
         EchonetInstance.__init__(self, host, self._eojgc, self._eojcc, instance, api_connector)
 
     def getMeasuredInstantPower(self):
-        return int.from_bytes(self.getMessage(0xE0), 'big')
+        return self.getMessage(0xE0)
 
     def getMeasuredCumulPower(self):
-        return int.from_bytes(self.getMessage(0xE1), 'big')
+        return self.getMessage(0xE1)

--- a/pychonet/StorageBattery.py
+++ b/pychonet/StorageBattery.py
@@ -15,12 +15,12 @@ class StorageBattery(EchonetInstance):
     }
 
     def __init__(self, host, api_connector = None, instance = 0x1):
-        self.eojgc = 0x02
-        self.eojcc = 0x7d
+        self._eojgc = 0x02
+        self._eojcc = 0x7d
         EchonetInstance.__init__(self, host, self._eojgc, self._eojcc, instance, api_connector)
 
     def getRemainingStoredElectricity3(self):
-        return int.from_bytes(self.getMessage(0xE4), 'big')
+        return self.getMessage(0xE4)
 
     def getWorkingOperationStatus(self):
-        return int.from_bytes(self.getMessage(0xCF), 'big')
+        return self.getMessage(0xCF)

--- a/pychonet/TemperatureSensor.py
+++ b/pychonet/TemperatureSensor.py
@@ -12,8 +12,8 @@ class TemperatureSensor(EchonetInstance):
     }
 
     def __init__(self, host, api_connector = None, instance = 0x1):
-        self.eojgc = 0x00
-        self.eojcc = 0x11
+        self._eojgc = 0x00
+        self._eojcc = 0x11
         EchonetInstance.__init__(self, host, self._eojgc, self._eojcc, instance, api_connector)
 
     def getMeasuredTemperature(self):


### PR DESCRIPTION
I believe these are all broken at the moment.

I cannot test these devices, but the same changes to a new device type I'm testing work fine.