### PR TITLE
`echonetMessage()` waits for client data updates

### DIFF
--- a/pychonet/lib/const.py
+++ b/pychonet/lib/const.py
@@ -10,7 +10,7 @@ VERSION = "2.3.0"
 
 ENL_PORT = 3610
 ENL_MULTICAST_ADDRESS = "224.0.23.0"
-MESSAGE_TIMEOUT = 100
+MESSAGE_TIMEOUT = 200
 
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
`echonetMessage()` must wait for data updates on the client side for accurate UI updates in HA.

Also, according to the ECHONET Lite specifications, the status reflection wait timer must wait up to 20 seconds, although it varies depending on the device class.

> https://echonet.jp/spec_g/#standard-02
> アプリケーション通信インターフェース仕様書