### PR TITLE
Added SingleFunctionLighting (0x02, 0x91)

### DIFF
--- a/pychonet/SingleFunctionLighting.py
+++ b/pychonet/SingleFunctionLighting.py
@@ -1,0 +1,38 @@
+from pychonet.EchonetInstance import EchonetInstance
+from pychonet.GeneralLighting import ENL_BRIGHTNESS
+
+# ----- Single function lighting class -------
+
+
+# TODO - implemenet FUNCTIONS
+# 	0xB0: 'Illuminance level setting',
+
+
+"""Class for Single Function Lighting Objects"""
+
+
+class SingleFunctionLighting(EchonetInstance):
+    def __init__(self, host, api_connector=None, instance=0x1):
+        self._eojgc = 0x02  # Housing/facility-related device group
+        self._eojcc = 0x91  # Single Function Lighting class
+        EchonetInstance.__init__(
+            self, host, self._eojgc, self._eojcc, instance, api_connector
+        )
+
+    """
+    getBrightness get the brightness that has been set in the light
+
+    return: A string representing the configured brightness.
+    """
+
+    def getBrightness(self):
+        return self.getMessage(ENL_BRIGHTNESS)  # ['brightness']
+
+    """
+    setBrightness set the temperature of the light
+
+    param temperature: A string representing the desired temperature.
+    """
+
+    def setBrightness(self, brightness):
+        return self.setMessage(ENL_BRIGHTNESS, int(brightness))

--- a/pychonet/__init__.py
+++ b/pychonet/__init__.py
@@ -7,6 +7,7 @@ from .ElectricBlind import ElectricBlind
 from .ElectricLock import ElectricLock
 from .ElectricVehicleCharger import ElectricVehicleCharger
 from .GeneralLighting import GeneralLighting
+from .SingleFunctionLighting import SingleFunctionLighting
 from .HomeAirCleaner import HomeAirCleaner
 from .HomeAirConditioner import HomeAirConditioner
 from .HomeSolarPower import HomeSolarPower
@@ -44,6 +45,7 @@ def Factory(host, server, eojgc, eojcc, eojci=0x01):
         f"{0x02}-{0x87}": DistributionPanelMeter,
         f"{0x02}-{0x88}": LowVoltageSmartElectricEnergyMeter,
         f"{0x02}-{0x90}": GeneralLighting,
+        f"{0x02}-{0x91}": SingleFunctionLighting,
         f"{0x02}-{0xA6}": HybridWaterHeater,
         None: None,
     }


### PR DESCRIPTION
Add support SingleFunctionLighting (as used by Advance Link Plus Wireless adapter WTY2001).

Note: in practice, when changing two lights very quickly (sending two message for change before first message came back), it seems `setMessage` returns false.
https://github.com/scottyphillips/pychonet/blob/master/pychonet/EchonetInstance.py#L66

I could think of several options to fix it:
1. For/While loop with retry count inside `setMessage` in pychonet
2. For/While loop with retry count on echonetlite_homeassistant side
3. Add a lock inside `setMessage` (I am not sure about the exact scope for such a lock, is it a limitation per host/system in which case the lock should be per host/system? is it only for this specific hardware device WTY2001 or a general ECHONET lite restriction?)

For now I did the fix 1, and it works fine.
I think I saw you did a similar fix for getting property map already?