### PR TITLE
fix #58 Consecutive requests to a device must wait for a response

### DIFF
--- a/pychonet/echonetapiclient.py
+++ b/pychonet/echonetapiclient.py
@@ -198,8 +198,10 @@ class ECHONETAPIClient:
                 # transaction sucessful remove from list
                 if self._failure_list.get(tx_tid) is None:
                     res = True
+                else:
+                    del self._failure_list[tx_tid]
                 break
-        if not res:
+        if not res and self._message_list.get(tx_tid) is not None:
             del self._message_list[tx_tid]
         self._waiting[host] -= 1
         return res

--- a/pychonet/lib/const.py
+++ b/pychonet/lib/const.py
@@ -29,7 +29,8 @@ EHD2 = {
 # ------------------------------------------------------------------
 # ESV
 # ------------------------------------------------------------------
-GETC = 0x60
+GETC = 0x60 # Deprecated, for backward compatibility
+SETI = 0x60
 SETC = 0x61
 GET = 0x62
 INFREQ = 0x63
@@ -49,7 +50,7 @@ INSTANCE_LIST = 0xD6
 
 ESV_CODES = {
     0x60: {
-        "name": "GetC",
+        "name": "SetI",
         "description": "Property value write request (no response required)",
     },
     0x61: {


### PR DESCRIPTION
If the controller sends successive requests to the device, it needs to wait for the response of the previous request, and it does so.