### PR TITLE
How about to have status values of "empty" or "not empty" of the icem…

### DIFF
--- a/pychonet/Refrigerator.py
+++ b/pychonet/Refrigerator.py
@@ -88,7 +88,7 @@ class Refrigerator(EchonetInstance):
         ],  # "Quick refrigeration function setting",
         0xA4: [_int, DICT_41_ENABLED_DISABLED_TEMPDISABLED],  # "Icemaker setting",
         0xA5: [_int, DICT_41_ENABLED_DISABLED],  # "Icemaker operation status",
-        0xA6: [_int, DICT_41_ENABLED_DISABLED],  # "Icemaker tank status",
+        0xA6: [_int, DICT_41_EMPTY_OR_NOT],  # "Icemaker tank status",
         0xA8: [
             _int,
             DICT_41_ON_OFF,

--- a/pychonet/Refrigerator.py
+++ b/pychonet/Refrigerator.py
@@ -1,5 +1,6 @@
 from pychonet.EchonetInstance import EchonetInstance
 from pychonet.lib.epc_functions import (
+    DICT_41_EMPTY_OR_NOT,
     DICT_41_ENABLED_DISABLED,
     DICT_41_ENABLED_DISABLED_TEMPDISABLED,
     DICT_41_OPEN_CLOSED,

--- a/pychonet/lib/epc_functions.py
+++ b/pychonet/lib/epc_functions.py
@@ -23,6 +23,7 @@ DICT_41_ENABLED_DISABLED = {0x41: "enabled", 0x42: "disabled"}
 DICT_41_AVAILABLE_NOT_AVAILABLE = {0x41: "available", 0x42: "not available"}
 DICT_41_HEATING_NOT_HEATING = {0x41: "heating", 0x42: "not heating"}
 DICT_41_PERMITTED_PROHIBITED = {0x41: "permitted", 0x42: "prohibited"}
+DICT_41_EMPTY_OR_NOT = {0x41: "not empty", 0x42: "empty"}
 DICT_30_TRUE_FALSE = {0x30: True, 0x31: False}
 DICT_30_ON_OFF = {0x30: DATA_STATE_ON, 0x31: DATA_STATE_OFF}
 DICT_30_OPEN_CLOSED = {0x30: DATA_STATE_OPEN, 0x31: DATA_STATE_CLOSE}


### PR DESCRIPTION
How about to have status values of "empty" or "not empty" of the icemaker tank entity?
This is just a (weak) proposal, since the current value of "enabled/disabled" is not intuitive (I think).

P.S.
I am slightly disappointed about the usage of the fridge via echonet (not blaming you at all...). There is no room of automation, except the notification of icemaker tank.  This PR is just for my automation.

P.P.S.
This PR is **not** tested at all. I do not know how echonetlite_homeassistant loads the pychonet  lib. Additionally, I am stuck at loading newer echonetlite_homeassistant due to the "integration is already in the store" error when trying to load new one.